### PR TITLE
TuneIn support, Command line argument changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Exclude python files
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -14,17 +14,19 @@ Also, the [VLC media player](https://www.videolan.org/vlc/) must be installed.
 
 ## Usage
 ```
-$ python3 pyradio.py
-usage: pyradio.py [-h] [-l] [-d] [-p STAT] [-v VOL]
+$ python3 pyradio.py -h
+usage: pyradio.py [-h] [-l] [-d] station [volume]
 
 Play your favorite radio station from the terminal
 
+positional arguments:
+  station         name of station to play
+  volume          playback volume (default: 100)
+
 optional arguments:
-  -h, --help            show this help message and exit
-  -l, --list            list all stations in local database
-  -d, --database        only use local station database
-  -p STAT, --play STAT  play specified radio station
-  -v VOL, --vol VOL     set playback volume (default: 100)
+  -h, --help      show this help message and exit
+  -l, --list      list all stations in local database
+  -d, --database  only use local station database
 ```
 ### Example
 ```bash
@@ -43,4 +45,4 @@ Follow this format:
 ## :scroll: License
 MIT License
 
-Copyright (c) 2018 Siddharth Dushantha
+Copyright (c) 2018 Siddharth Dushantha, TeilzeitTaco

--- a/README.md
+++ b/README.md
@@ -9,28 +9,31 @@ $ git clone https://github.com/sdushantha/pyradio
 # install the requirements
 $ pip3 install -r requirements.txt
 ```
-This will clone the repository to your local PC and install the dependencies, python-vlc and colorama.
+This will clone the repository to your local PC and install the dependencies, python-vlc, colorama and requests.
+Also, the [VLC media player](https://www.videolan.org/vlc/) must be installed.
 
 ## Usage
 ```
 $ python3 pyradio.py
-usage: pyradio.py [-h] [-l] [-p STAT] [-v VOL]
+usage: pyradio.py [-h] [-l] [-d] [-p STAT] [-v VOL]
 
 Play your favorite radio station from the terminal
 
 optional arguments:
   -h, --help            show this help message and exit
-  -l, --list            list available radio stations
+  -l, --list            list all stations in local database
+  -d, --database        only use local station database
   -p STAT, --play STAT  play specified radio station
   -v VOL, --vol VOL     set playback volume (default: 100)
 ```
 ### Example
 ```bash
-$ python3 pyradio.py -p NRJ
+$ python3 pyradio.py -p "NRJ"
 ```
 
 ## Adding Radio Stations
-To add more stations, add the URL pointing to the stream to the ```stations.json``` file.
+```pyradio.py``` will search all unkown radio stations on [TuneIn](https://tunein.com/) and add them to the local database if anything is found.
+Alternatively you also can add a station manually, to do so, add the URL pointing to the stream to the ```stations.json``` file.
 
 Follow this format:
 ```

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ optional arguments:
 ```
 ### Example
 ```bash
-$ python3 pyradio.py -p "NRJ"
+$ python3 pyradio.py "NRJ"
 ```
 
 ## Adding Radio Stations

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ usage: pyradio.py [-h] [-l] [-d] station [volume]
 Play your favorite radio station from the terminal
 
 positional arguments:
-  station         name of station to play
+  station         name of station to play, checked on TuneIn if unkown
   volume          playback volume (default: 100)
 
 optional arguments:

--- a/pyradio.py
+++ b/pyradio.py
@@ -135,8 +135,8 @@ def main():
                         help="list all stations in local database")
 
     # This way, "station" can be a required positional argument,
-    # but only if "--list" is not given.
-    if not any(elem in sys.argv for elem in ["-l", "--list"]):
+    # but only if "--list" is not given. Also, we need to add these parameters if the user called "-h".
+    if not(any(elem in sys.argv for elem in ["-l", "--list"])) or any(elem in sys.argv for elem in ["-h", "--help"]):
         parser.add_argument("-d", "--database",
                             action="store_true",
                             help="only use local station database")

--- a/pyradio.py
+++ b/pyradio.py
@@ -58,8 +58,9 @@ def play_radio(station, vol, database):
             print(colors.RED + "Invalid station. Use --list to list all available stations." + colors.ENDC)
             sys.exit()
 
-        station_id  = tunein.query_id(station)
-        station_url = tunein.get_stream_link(station_id)
+        station_data = tunein.query_data(station)
+        station_url  = tunein.get_stream_link(station_data[1])
+        station      = station_data[0] # Set station name as reported by TuneIn
 
         print(colors.BOLD + "Adding station to database... " + colors.ENDC, end="")
 
@@ -132,29 +133,28 @@ def main():
                         action="store_true",
                         help="list all stations in local database")
 
-    parser.add_argument("-d", "--database",
-                        action="store_true",
-                        help="only use local station database")
+    # This way, "station" can be a required positional argument,
+    # but only if "--list" is not given.
+    if not any(elem in sys.argv for elem in ["-l", "--list"]):
+        parser.add_argument("-d", "--database",
+                            action="store_true",
+                            help="only use local station database")
 
-    parser.add_argument("-p", "--play",
-                        metavar="NAME", type=str,
-                        help="play specified radio station")
+        parser.add_argument("station",
+                            type=str,
+                            help="name of station to play")
 
-    parser.add_argument("-v", "--volume",
-                        metavar="VOL", type=int, default=100,
-                        help="set playback volume (default: 100)")
+        parser.add_argument("volume",
+                            type=int, default=100, nargs='?',
+                            help="playback volume (default: 100)")
 
     args = parser.parse_args()
 
-    # If program is called without arguments, show help
-    if len(sys.argv) == 1:
-        parser.print_help()
-
-    if args.play:
-        play_radio(args.play, args.volume, args.database)
-
-    elif args.list:
+    if args.list:
         show_stations()
+
+    elif args.station:
+        play_radio(args.station, args.volume, args.database)
 
     sys.exit()
 

--- a/pyradio.py
+++ b/pyradio.py
@@ -2,12 +2,13 @@
 
 import argparse
 import json
+import requests
 import signal
 import sys
-import requests
 
-import vlc
 import colorama
+import vlc
+
 import tunein
 
 
@@ -142,7 +143,7 @@ def main():
 
         parser.add_argument("station",
                             type=str,
-                            help="name of station to play")
+                            help="name of station to play, checked on TuneIn if unkown")
 
         parser.add_argument("volume",
                             type=int, default=100, nargs='?',

--- a/pyradio.py
+++ b/pyradio.py
@@ -50,6 +50,7 @@ def play_radio(station, vol, database):
     try:
         # Check stations.json
         station_url = stations[station]
+        print(colors.YELLOW + "Station found in local database." + colors.ENDC)
     except KeyError:
         print(colors.YELLOW + "Station not found in local database." + colors.ENDC)
 
@@ -74,21 +75,27 @@ def play_radio(station, vol, database):
 
     # Checking if the url is reachable. If not,
     # there might be a typo in the stations.json file
+    print(colors.BOLD + "Contacting station... " + colors.ENDC, end="")
+
     try:
         # Set stream to true so we only get the headers and dont load the body
         # otherwise it would hang and try to load the infinite stream
-        r = requests.get(station_url, stream=True)
+        with requests.get(station_url, stream=True) as r:
+            # 200 is the default HTTP response code, if we get something else,
+            # we can not play the stream (Debug : https://httpstat.us/)
+            if r.status_code != 200:
+                print(colors.RED + "Error!" + colors.ENDC)
+                print(colors.RED + "Station unreachable: Site not working! Error " +
+                    str(r.status_code) + "!" + colors.ENDC)
 
-        # 200 is the default HTTP response code
-        # if we get something else, we can not play the stream
-        if r.status_code != 200:
-            print(colors.RED + "Station not reachable: Site not working: Error " +
-                str(r.status_code) + "!" + colors.ENDC)
+                sys.exit()
 
-            sys.exit()
     except requests.ConnectionError:
-        print(colors.RED + "Station not reachable: Unable to connect!" + colors.ENDC)
+        print(colors.RED + "Error!" + colors.ENDC)
+        print(colors.RED + "Station unreachable: Unable to connect!" + colors.ENDC)
         sys.exit()
+
+    print(colors.GREEN + "OK!" + colors.ENDC)
 
     p = vlc.MediaPlayer(station_url)
     p.audio_set_volume(vol)

--- a/pyradio.py
+++ b/pyradio.py
@@ -34,12 +34,13 @@ def load_stations():
 def show_stations():
     stations = load_stations()
 
-    print("Available stations:\n")
+    print("\nAvailable stations:\n")
     for key, value in stations.items():
 
-        # Formatted print
-        print((colors.GREEN + "{0:16}" + colors.ENDC + colors.YELLOW + " @ " + colors.ENDC + colors.UNDERLINE + "{1}" + colors.ENDC)
-              .format(key, value))
+        # Formatted print, dynamic for longest station name
+        print((colors.GREEN + "{0:" + str(len(max(stations, key=len))) + "}"
+             + colors.ENDC + colors.YELLOW + " @ " + colors.ENDC + colors.UNDERLINE + "{1}" + colors.ENDC)
+             .format(key, value))
 
 
 def play_radio(station, vol, database):
@@ -52,13 +53,13 @@ def play_radio(station, vol, database):
         print(colors.YELLOW + "Station not found in local database." + colors.ENDC)
 
         # Should we check TuneIn?
-        if not database:
-            station_id  = tunein.query_tunein(station)
-            station_url = tunein.get_tunein_stream(station_id)
-        else:
-            # Throw error if search returned nothing
+        if database:
+            # No, user disabled it. Throw error.
             print(colors.RED + "Invalid station. Use --list to list all available stations." + colors.ENDC)
             sys.exit()
+
+        station_id  = tunein.query_id(station)
+        station_url = tunein.get_stream_link(station_id)
 
         print(colors.BOLD + "Adding station to database... " + colors.ENDC, end="")
 
@@ -135,20 +136,22 @@ def main():
                         action="store_true",
                         help="only use local station database")
 
-    parser.add_argument("-p", "--play", metavar="STAT",
+    parser.add_argument("-p", "--play",
+                        metavar="NAME", type=str,
                         help="play specified radio station")
 
-    parser.add_argument("-v", "--vol", type=int, default=100,
+    parser.add_argument("-v", "--volume",
+                        metavar="VOL", type=int, default=100,
                         help="set playback volume (default: 100)")
 
     args = parser.parse_args()
 
-    # If argument is given show help
+    # If program is called without arguments, show help
     if len(sys.argv) == 1:
         parser.print_help()
 
     if args.play:
-        play_radio(str(args.play), args.vol, args.database)
+        play_radio(args.play, args.volume, args.database)
 
     elif args.list:
         show_stations()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 python-vlc
 colorama
+requests

--- a/stations.json
+++ b/stations.json
@@ -1,11 +1,11 @@
 {
-  "NRJ": "http://stream.p4.no/nrj_mp3_mq?Nettplayer",
-  "P4": "http://stream.p4.no/p4_mp3_mq?Nettplayer_P4.no",
-  "Cub FM UAE": "http://20073.live.streamtheworld.com/CLUBFMUAEAAC.aac",
-  "NRK Folkemusikk": "http://lyd.nrk.no/nrk_radio_folkemusikk_mp3_m",
-  "P6 Rock": "http://stream.p4.no/p6_mp3_mq?Nettplayer_P6.no",
-  "JaerRadioen": "http://stream.jaerradiogruppen.no:8018/;stream.mp3",
-  "NRK P3": "http://lyd.nrk.no/nrk_radio_p3_mp3_m",
-  "radi/u/": "http://radio.dangeru.us:8000/stream.ogg",
-  "OE3": "https://oe3shoutcast.sf.apa.at/"
+    "Cub FM UAE": "http://20073.live.streamtheworld.com/CLUBFMUAEAAC.aac",
+    "JaerRadioen": "http://stream.jaerradiogruppen.no:8018/;stream.mp3",
+    "NRJ": "http://stream.p4.no/nrj_mp3_mq?Nettplayer",
+    "NRK Folkemusikk": "http://lyd.nrk.no/nrk_radio_folkemusikk_mp3_m",
+    "NRK P3": "http://lyd.nrk.no/nrk_radio_p3_mp3_m",
+    "OE3": "https://oe3shoutcast.sf.apa.at/",
+    "P4": "http://stream.p4.no/p4_mp3_mq?Nettplayer_P4.no",
+    "P6 Rock": "http://stream.p4.no/p6_mp3_mq?Nettplayer_P6.no",
+    "radi/u/": "http://radio.dangeru.us:8000/stream.ogg"
 }

--- a/tunein.py
+++ b/tunein.py
@@ -24,7 +24,7 @@ TUNEIN_SEARCH     = "/search/?query="
 TUNEIN_LINKSERVER = "https://opml.radiotime.com/Tune.ashx?id={}&render=json&listenId=1555086519&itemToken=BgUFAAEAAQABAAEAb28BKyAAAAEFAAA&formats=mp3,aac,ogg,flash,html,hls&type=station&serial=a79c8cb1-e983-4dff-a0e2-7b95771e8657&partnerId=RadioTime&version=3.14&itemUrlScheme=secure&reqAttempt=1"
 
 
-def query_tunein(query):
+def query_id(query):
     # Get TuneIn sub-link from the TuneIn search page.
     print(colors.BOLD + "Querying TuneIn... " + colors.ENDC, end='')
 
@@ -53,7 +53,7 @@ def query_tunein(query):
     sys.exit()
 
 
-def get_tunein_stream(station_id):
+def get_stream_link(station_id):
     # Get stream url directly from the TuneIn servers
     # Bonus: Bypasses ads! :D
     print(colors.BOLD + "Getting stream url... " + colors.ENDC, end="")
@@ -69,8 +69,9 @@ def get_tunein_stream(station_id):
     r = requests.get(TUNEIN_LINKSERVER.format(m.group(1)))
     respondedJson = json.loads(r.text)
 
-    # The JSON data may contain more than one entry in the body list,
-    # so we use [0] to just select the first one.
+    # The received JSON data may contain more than one entry in the body list,
+    # for different audio qualities. The best quality is listed first,
+    # so we use [0] to select the first one.
     if respondedJson["body"][0]["url"]:
         print(colors.GREEN + "OK!" + colors.ENDC)
         return respondedJson["body"][0]["url"]

--- a/tunein.py
+++ b/tunein.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+
+import re
+import requests
+import json
+import sys
+
+
+# Heh, ripped from the Blender build scripts
+class colors:
+    GREEN     = '\033[92m'
+    RED       = '\033[91m'
+    YELLOW    = '\033[93m'
+    BOLD      = '\033[1m'
+    UNDERLINE = '\033[4m'
+    ENDC      = '\033[0m'
+
+
+# TuneIn constants
+TUNEIN_ROOT       = "https://tunein.com"
+TUNEIN_SEARCH     = "/search/?query="
+
+# Hellish link: I dont fully understand it, but it works.
+TUNEIN_LINKSERVER = "https://opml.radiotime.com/Tune.ashx?id={}&render=json&listenId=1555086519&itemToken=BgUFAAEAAQABAAEAb28BKyAAAAEFAAA&formats=mp3,aac,ogg,flash,html,hls&type=station&serial=a79c8cb1-e983-4dff-a0e2-7b95771e8657&partnerId=RadioTime&version=3.14&itemUrlScheme=secure&reqAttempt=1"
+
+
+def query_tunein(query):
+    # Get TuneIn sub-link from the TuneIn search page.
+    print(colors.BOLD + "Querying TuneIn... " + colors.ENDC, end='')
+
+    # We need to filter the query to make it url conform
+    query = query.replace(" ", "%20")
+    query = query.replace("/", "%2F")
+    query = query.replace(".", "")
+
+    # Get html source code from website
+    r = requests.get(TUNEIN_ROOT + TUNEIN_SEARCH + query)
+
+    # Get the link with regex
+    query      = query.replace("%2F", "")
+    query      = query.replace("%20", "-")
+    station_id = re.search("href=\"(.{0,64}" + query + ".{0,64})\/\">",
+        r.text, flags=re.IGNORECASE)
+
+    # Return or throw error
+    if station_id:
+        print(colors.GREEN + "OK!" + colors.ENDC)
+        return station_id.group(1)
+
+    # Throw error
+    print(colors.RED + "Error!" + colors.ENDC)
+    print(colors.RED + "Unable to get TuneIn ID: Error finding query on TuneIn!" + colors.ENDC)
+    sys.exit()
+
+
+def get_tunein_stream(station_id):
+    # Get stream url directly from the TuneIn servers
+    # Bonus: Bypasses ads! :D
+    print(colors.BOLD + "Getting stream url... " + colors.ENDC, end="")
+
+    # We only need the ID, not the whole sub-link
+    m = re.search("-(s.{0,32}$)", station_id)
+    if not m:
+        print(colors.RED + "Error!" + colors.ENDC)
+        print(colors.RED + "Unable to get TuneIn stream: Invalid parameters!" + colors.ENDC)
+        sys.exit()
+
+    # Lets request the station server address from the TuneIn database
+    r = requests.get(TUNEIN_LINKSERVER.format(m.group(1)))
+    respondedJson = json.loads(r.text)
+
+    # The JSON data may contain more than one entry in the body list,
+    # so we use [0] to just select the first one.
+    if respondedJson["body"][0]["url"]:
+        print(colors.GREEN + "OK!" + colors.ENDC)
+        return respondedJson["body"][0]["url"]
+
+    # Throw error
+    print(colors.RED + "Error!" + colors.ENDC)
+    print(colors.RED + "Unable to get TuneIn stream: Server error!" + colors.ENDC)
+    sys.exit()

--- a/tunein.py
+++ b/tunein.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 
+import json
 import re
 import requests
-import json
 import sys
 
 
@@ -24,7 +24,7 @@ TUNEIN_FILTER     = "<h2 class=\"container-title__titleHeader___T_Nit\" data-tes
 
 
 def query_data(query):
-    # Get TuneIn sub-link from the TuneIn search page.
+    # Get station name and ID from TuneIn search page
     print(colors.BOLD + "Querying TuneIn... " + colors.ENDC, end='')
 
     # We need to filter the query to make it url conform
@@ -35,7 +35,7 @@ def query_data(query):
     # Get html source code from website
     r = requests.get(TUNEIN_SEARCH + query)
 
-    # Magic regex: only find elements of the stations list and get name and ID.
+    # Magic regex: only find elements of the stations list and get name and ID
     station_id = re.findall(TUNEIN_FILTER, r.text)
 
     # Search successful?
@@ -43,7 +43,7 @@ def query_data(query):
         print(colors.GREEN + "OK!" + colors.ENDC)
         return station_id[0]
 
-    # Throw error
+    # Throw error if unsuccessful
     print(colors.RED + "Error!" + colors.ENDC)
     print(colors.RED + "Unable to get TuneIn ID: Error finding query on TuneIn!" + colors.ENDC)
     sys.exit()


### PR DESCRIPTION
* [TuneIn](https://tunein.com/) Support
  TuneIn is a internet radio platform hosting thousands of online radio stations. I modified pyradio to search the entered station name on TuneIn and obatin the stream url if it wasnt found in stations.json. This can be disabled with the -d command line option.
* Commandline arguments
  The station name and volume now are positional arguments. Added -d option.
* Updated from urllib2 to requests
  I updated pyradio to use the newer requests library instead of the older urllib2 library.
* Minor changes
  The station list now supports station names of arbitrary length.
  The ReadMe was updated to reflect these changes.


I hope I didnt break Linux/OS X support with any of my changes, I dont have a machine to test this right now.